### PR TITLE
Prevent error when file name contains more than 1 period

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = function({ file, width, height, type }) {
     return new Promise(function (resolve, reject) {
         let allow = ['jpg', 'gif', 'bmp', 'png', 'jpeg'];
         try {
-            if (file.name && file.name.split(".")[1] && allow.includes(file.name.split(".")[1].toLowerCase()) && file.size && file.type) {
+            if (file.name && file.name.split(".").reverse()[0] && allow.includes(file.name.split(".").reverse()[0].toLowerCase()) && file.size && file.type) {
                 let imageType = type ? type : 'jpeg';
                 const imgWidth = width ? width : 500;
                 const imgHeight = height ? height : 300;


### PR DESCRIPTION
#### Issue description
The module does not work when a file name contains a period.

#### Steps to reproduce the issue
1. Convert a file with a period in its name. E.g. "Screen Shot 2018-07-30 at 16.54.46.png"

#### What's the expected result?
- No error to happen, because the image is valid

#### What's the actual result?
- Module says "File not supported!"

#### Additional details
 The fix is very simple, so hopefully it does not take long to merge. I'd love to get back to using the official module.
